### PR TITLE
Fix launch date formatting in correct timezone

### DIFF
--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -25,6 +25,7 @@ import { useSpaceX } from "../utils/use-space-x";
 import { formatDateTime } from "../utils/format-date";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
+import { getLaunchpadTimezone } from "../utils/launch-pad-timezones";
 
 export default function Launch() {
   let { launchId } = useParams();
@@ -124,7 +125,10 @@ function TimeAndLocation({ launch }) {
           </Box>
         </StatLabel>
         <StatNumber fontSize={["md", "xl"]}>
-          {formatDateTime(launch.launch_date_local)}
+          {formatDateTime(
+            launch.launch_date_local,
+            getLaunchpadTimezone(launch.launch_site.site_name),
+          )}
         </StatNumber>
         <StatHelpText>{timeAgo(launch.launch_date_utc)}</StatHelpText>
       </Stat>

--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -19,6 +19,7 @@ import {
   Stack,
   AspectRatioBox,
   StatGroup,
+  Tooltip,
 } from "@chakra-ui/core";
 
 import { useSpaceX } from "../utils/use-space-x";
@@ -125,10 +126,15 @@ function TimeAndLocation({ launch }) {
           </Box>
         </StatLabel>
         <StatNumber fontSize={["md", "xl"]}>
-          {formatDateTime(
-            launch.launch_date_local,
-            getLaunchpadTimezone(launch.launch_site.site_name),
-          )}
+          <Tooltip
+            label={formatDateTime(launch.launch_date_local)}
+            aria-label="Local time launch date"
+          >
+            {formatDateTime(
+              launch.launch_date_local,
+              getLaunchpadTimezone(launch.launch_site.site_name),
+            )}
+          </Tooltip>
         </StatNumber>
         <StatHelpText>{timeAgo(launch.launch_date_utc)}</StatHelpText>
       </Stat>

--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -7,7 +7,7 @@ export function formatDate(timestamp) {
   }).format(new Date(timestamp));
 }
 
-export function formatDateTime(timestamp) {
+export function formatDateTime(timestamp, timeZone) {
   return new Intl.DateTimeFormat("en-US", {
     year: "numeric",
     month: "long",
@@ -16,5 +16,7 @@ export function formatDateTime(timestamp) {
     minute: "numeric",
     second: "numeric",
     timeZoneName: "short",
+    timeZone,
+
   }).format(new Date(timestamp));
 }

--- a/src/utils/launch-pad-timezones.js
+++ b/src/utils/launch-pad-timezones.js
@@ -1,0 +1,16 @@
+const LAUNCH_PAD_TIMEZONES = {
+  "CCAFS SLC 40": "America/New_York",
+  "KSC LC 39A": "America/New_York",
+  "Kwajalein Atoll": "Pacific/Majuro",
+  "STLS": "America/Chicago",
+  "VAFB SLC 3W": "America/Los_Angeles",
+  "VAFB SLC 4E": "America/Los_Angeles",
+};
+
+/**
+ * Get timezone of a launchpad in IANA format accepted by Intl.DateTimeFormat.
+ * Fallback to UTC if it doesn't find a match.
+ */
+export function getLaunchpadTimezone (launchPadName) {
+  return LAUNCH_PAD_TIMEZONES[launchPadName] ?? "UTC";
+}


### PR DESCRIPTION
In launch detail, the date is now formatted in the timezone based on the location of the launch pad.

On hover, we show a tooltip with the launch date formatted in user's timezone.

I was considering these options on how to get the proper timezone of the launchpad:

Naively parse time difference from date string that is returned from the API.
This seems error prone, also I'm not sure if there wouldn't be problems with DST.

I could add a datetime library such as Luxon to handle the parsing properly, but that seemed like an overkill for such a trivial feature. On a bigger project I'd probably add it because I would use it more on future features.
In both cases the end user wouldn't see the actual timezone, but only the time difference to UTC, e.g. UTC-7

I've decided to hardcode the timezones of each launch pad. If a timezone is not found, there's still fallback to UTC time difference.

I could use the launchpad endpoint and something like Google Timezone API to fetch the timezones dynamically, but that seemed like a too complex solution for this fix. I reckon the launchpads don’t get updated that frequently and we can add some logging (to Sentry for example) in case there's a new launch pad added and we miss it.

I would also add this info to some knowledge base for future reference.