### PR TITLE
Add favourites lists to launches and launch pads

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -7,18 +7,21 @@ import Launch from "./launch";
 import Home from "./home";
 import LaunchPads from "./launch-pads";
 import LaunchPad from "./launch-pad";
+import { FavouritesContextProvider } from "../utils/favourites-context";
 
 export default function App() {
   return (
     <div>
-      <NavBar />
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/launches" element={<Launches />} />
-        <Route path="/launches/:launchId" element={<Launch />} />
-        <Route path="/launch-pads" element={<LaunchPads />} />
-        <Route path="/launch-pads/:launchPadId" element={<LaunchPad />} />
-      </Routes>
+      <FavouritesContextProvider>
+        <NavBar />
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/launches" element={<Launches />} />
+          <Route path="/launches/:launchId" element={<Launch />} />
+          <Route path="/launch-pads" element={<LaunchPads />} />
+          <Route path="/launch-pads/:launchPadId" element={<LaunchPad />} />
+        </Routes>
+      </FavouritesContextProvider>
     </div>
   );
 }

--- a/src/components/favourite-button.js
+++ b/src/components/favourite-button.js
@@ -1,0 +1,21 @@
+import React from "react";
+import { Star } from "react-feather";
+import { IconButton } from "@chakra-ui/core";
+
+export default function FavouriteButton({ onClick, isFavourite }) {
+  function handleFavouriteClick(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    onClick();
+  }
+
+  return (
+    <IconButton
+      aria-label="Favourite button"
+      variantColor={isFavourite ? "teal" : undefined}
+      aria-pressed={isFavourite}
+      icon={Star}
+      onClick={handleFavouriteClick}
+    />
+  );
+}

--- a/src/components/favourite-launch-button.js
+++ b/src/components/favourite-launch-button.js
@@ -1,0 +1,23 @@
+import React from "react";
+import { Star } from "react-feather";
+import { IconButton } from "@chakra-ui/core";
+import { useFavouriteLaunch } from "../utils/favourites-context";
+
+export default function FavouriteLaunchButton({ launchId }) {
+  const { isFavourite, toggleFavouriteLaunch } = useFavouriteLaunch(launchId);
+
+  function handleFavouriteClick(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    toggleFavouriteLaunch();
+  }
+
+  return (
+    <IconButton
+      aria-label="Favourite button"
+      variantColor={isFavourite ? "teal" : undefined}
+      icon={Star}
+      onClick={handleFavouriteClick}
+    />
+  );
+}

--- a/src/components/favourite-launch-button.js
+++ b/src/components/favourite-launch-button.js
@@ -1,23 +1,14 @@
 import React from "react";
-import { Star } from "react-feather";
-import { IconButton } from "@chakra-ui/core";
 import { useFavouriteLaunch } from "../utils/favourites-context";
+import FavouriteButton from "./favourite-button";
 
 export default function FavouriteLaunchButton({ launchId }) {
   const { isFavourite, toggleFavouriteLaunch } = useFavouriteLaunch(launchId);
 
-  function handleFavouriteClick(event) {
-    event.preventDefault();
-    event.stopPropagation();
-    toggleFavouriteLaunch();
-  }
-
   return (
-    <IconButton
-      aria-label="Favourite button"
-      variantColor={isFavourite ? "teal" : undefined}
-      icon={Star}
-      onClick={handleFavouriteClick}
+    <FavouriteButton
+      isFavourite={isFavourite}
+      onClick={toggleFavouriteLaunch}
     />
   );
 }

--- a/src/components/favourite-launch-pad-button.js
+++ b/src/components/favourite-launch-pad-button.js
@@ -1,23 +1,14 @@
 import React from "react";
-import { Star } from "react-feather";
-import { IconButton } from "@chakra-ui/core";
 import { useFavouriteLaunchPad } from "../utils/favourites-context";
+import FavouriteButton from "./favourite-button";
 
 export default function FavouriteLaunchPadButton({ launchPadId }) {
   const { isFavourite, toggleFavouriteLaunchPad } = useFavouriteLaunchPad(launchPadId);
 
-  function handleFavouriteClick(event) {
-    event.preventDefault();
-    event.stopPropagation();
-    toggleFavouriteLaunchPad();
-  }
-
   return (
-    <IconButton
-      aria-label="Favourite button"
-      variantColor={isFavourite ? "teal" : undefined}
-      icon={Star}
-      onClick={handleFavouriteClick}
+    <FavouriteButton
+      isFavourite={isFavourite}
+      onClick={toggleFavouriteLaunchPad}
     />
   );
 }

--- a/src/components/favourite-launch-pad-button.js
+++ b/src/components/favourite-launch-pad-button.js
@@ -1,0 +1,23 @@
+import React from "react";
+import { Star } from "react-feather";
+import { IconButton } from "@chakra-ui/core";
+import { useFavouriteLaunchPad } from "../utils/favourites-context";
+
+export default function FavouriteLaunchPadButton({ launchPadId }) {
+  const { isFavourite, toggleFavouriteLaunchPad } = useFavouriteLaunchPad(launchPadId);
+
+  function handleFavouriteClick(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    toggleFavouriteLaunchPad();
+  }
+
+  return (
+    <IconButton
+      aria-label="Favourite button"
+      variantColor={isFavourite ? "teal" : undefined}
+      icon={Star}
+      onClick={handleFavouriteClick}
+    />
+  );
+}

--- a/src/components/favourite-launch-pads.js
+++ b/src/components/favourite-launch-pads.js
@@ -1,0 +1,44 @@
+import React, { Fragment } from "react";
+import { Box, Flex, Text } from "@chakra-ui/core";
+import styled from "@emotion/styled";
+import Error from "./error";
+import { useSpaceX } from "../utils/use-space-x";
+import FavouritesDrawer from "./favourites-drawer";
+import { useFavouriteLaunchPads } from "../utils/favourites-context";
+import LaunchPadItem from "./launch-pad-item";
+
+const Spacer = styled.div`
+  height: 1rem;
+`;
+
+export default function FavouriteLaunchPads() {
+  const favouriteLaunchPads = useFavouriteLaunchPads();
+  return (
+    <FavouritesDrawer>
+      <Flex direction="column" role="list" aria-label="Favourites list">
+        {favouriteLaunchPads.length === 0 && (
+          <Text>
+            No favourite launch pads yet.
+          </Text>
+        )}
+        {favouriteLaunchPads.map((launchPadId) => (
+          <Fragment key={launchPadId}>
+            <FavouriteLaunchPadItem launchPadId={launchPadId} />
+            {/* FIXME: Stack spacing prop doesn't work, upgrade Chakra UI */}
+            <Spacer />
+          </Fragment>
+        ))}
+      </Flex>
+    </FavouritesDrawer>
+  );
+}
+
+function FavouriteLaunchPadItem({ launchPadId }) {
+  const { data: launchPad, error } = useSpaceX(`/launchpads/${launchPadId}`);
+  return (
+    <Box>
+      {error && <Error />}
+      {launchPad && <LaunchPadItem launchPad={launchPad} variant="favourites-list" />}
+    </Box>
+  );
+}

--- a/src/components/favourite-launches.js
+++ b/src/components/favourite-launches.js
@@ -38,7 +38,7 @@ function FavouriteLaunchItem({ launchId }) {
   return (
     <Box>
       {error && <Error />}
-      {launch && <LaunchItem launch={launch} />}
+      {launch && <LaunchItem launch={launch} variant="favourites-list" />}
     </Box>
   );
 }

--- a/src/components/favourite-launches.js
+++ b/src/components/favourite-launches.js
@@ -1,0 +1,44 @@
+import React, { Fragment } from "react";
+import { Box, Flex, Text } from "@chakra-ui/core";
+import styled from "@emotion/styled";
+import Error from "./error";
+import LaunchItem from "./launch-item";
+import { useSpaceX } from "../utils/use-space-x";
+import FavouritesDrawer from "./favourites-drawer";
+import { useFavouriteLaunches } from "../utils/favourites-context";
+
+const Spacer = styled.div`
+  height: 1rem;
+`;
+
+export default function FavouriteLaunches() {
+  const favouriteLaunches = useFavouriteLaunches();
+  return (
+    <FavouritesDrawer>
+      <Flex direction="column" role="list" aria-label="Favourites list">
+        {favouriteLaunches.length === 0 && (
+          <Text>
+            No favourite launches yet.
+          </Text>
+        )}
+        {favouriteLaunches.map((launchId) => (
+          <Fragment key={launchId}>
+            <FavouriteLaunchItem launchId={launchId} />
+            {/* FIXME: Stack spacing prop doesn't work, upgrade Chakra UI */}
+            <Spacer />
+          </Fragment>
+        ))}
+      </Flex>
+    </FavouritesDrawer>
+  );
+}
+
+function FavouriteLaunchItem({ launchId }) {
+  const { data: launch, error } = useSpaceX(`/launches/${launchId}`);
+  return (
+    <Box>
+      {error && <Error />}
+      {launch && <LaunchItem launch={launch} />}
+    </Box>
+  );
+}

--- a/src/components/favourites-drawer.js
+++ b/src/components/favourites-drawer.js
@@ -1,0 +1,39 @@
+import React from "react";
+import {
+  Button,
+  Drawer,
+  DrawerOverlay,
+  DrawerContent,
+  DrawerCloseButton,
+  DrawerHeader,
+  DrawerBody,
+  useDisclosure,
+} from "@chakra-ui/core";
+import { Star } from "react-feather";
+
+export default function FavouritesDrawer({ children }) {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const btnRef = React.useRef();
+
+  return (
+    <>
+      <Button ref={btnRef} leftIcon={Star} onClick={onOpen}>
+        Favourites
+      </Button>
+      <Drawer
+        isOpen={isOpen}
+        placement="right"
+        onClose={onClose}
+        finalFocusRef={btnRef}
+        size="sm"
+      >
+        <DrawerOverlay />
+        <DrawerContent>
+          <DrawerCloseButton />
+          <DrawerHeader>Favourites</DrawerHeader>
+          <DrawerBody overflowY="auto">{children}</DrawerBody>
+        </DrawerContent>
+      </Drawer>
+    </>
+  );
+}

--- a/src/components/launch-item.js
+++ b/src/components/launch-item.js
@@ -4,6 +4,7 @@ import { format as timeAgo } from "timeago.js";
 import { Link } from "react-router-dom";
 
 import { formatDate } from "../utils/format-date";
+import FavouriteLaunchButton from "./favourite-launch-button";
 
 export default function LaunchItem({ launch }) {
   return (
@@ -15,6 +16,8 @@ export default function LaunchItem({ launch }) {
       rounded="lg"
       overflow="hidden"
       position="relative"
+      display="block"
+      aria-label="Launch item"
     >
       <Image
         src={
@@ -60,15 +63,20 @@ export default function LaunchItem({ launch }) {
             {launch.rocket.rocket_name} &bull; {launch.launch_site.site_name}
           </Box>
         </Box>
-        <Box
-          mt="1"
-          fontWeight="semibold"
-          as="h4"
-          lineHeight="tight"
-          isTruncated
-        >
-          {launch.mission_name}
-        </Box>
+
+        <Flex justify="space-between">
+          <Box
+            mt="1"
+            fontWeight="semibold"
+            as="h4"
+            lineHeight="tight"
+            isTruncated
+            aria-label="Launch mission name"
+          >
+            {launch.mission_name}
+          </Box>
+          <FavouriteLaunchButton launchId={launch.flight_number} />
+        </Flex>
         <Flex>
           <Text fontSize="sm">{formatDate(launch.launch_date_utc)} </Text>
           <Text color="gray.500" ml="2" fontSize="sm">

--- a/src/components/launch-item.js
+++ b/src/components/launch-item.js
@@ -1,0 +1,81 @@
+import React from "react";
+import { Badge, Box, Image, Text, Flex } from "@chakra-ui/core";
+import { format as timeAgo } from "timeago.js";
+import { Link } from "react-router-dom";
+
+import { formatDate } from "../utils/format-date";
+
+export default function LaunchItem({ launch }) {
+  return (
+    <Box
+      as={Link}
+      to={`/launches/${launch.flight_number.toString()}`}
+      boxShadow="md"
+      borderWidth="1px"
+      rounded="lg"
+      overflow="hidden"
+      position="relative"
+    >
+      <Image
+        src={
+          launch.links.flickr_images[0]?.replace("_o.jpg", "_z.jpg") ??
+          launch.links.mission_patch_small
+        }
+        alt={`${launch.mission_name} launch`}
+        height={["200px", null, "300px"]}
+        width="100%"
+        objectFit="cover"
+        objectPosition="bottom"
+      />
+
+      <Image
+        position="absolute"
+        top="5"
+        right="5"
+        src={launch.links.mission_patch_small}
+        height="75px"
+        objectFit="contain"
+        objectPosition="bottom"
+      />
+
+      <Box p="6">
+        <Box d="flex" alignItems="baseline">
+          {launch.launch_success ? (
+            <Badge px="2" variant="solid" variantColor="green">
+              Successful
+            </Badge>
+          ) : (
+            <Badge px="2" variant="solid" variantColor="red">
+              Failed
+            </Badge>
+          )}
+          <Box
+            color="gray.500"
+            fontWeight="semibold"
+            letterSpacing="wide"
+            fontSize="xs"
+            textTransform="uppercase"
+            ml="2"
+          >
+            {launch.rocket.rocket_name} &bull; {launch.launch_site.site_name}
+          </Box>
+        </Box>
+        <Box
+          mt="1"
+          fontWeight="semibold"
+          as="h4"
+          lineHeight="tight"
+          isTruncated
+        >
+          {launch.mission_name}
+        </Box>
+        <Flex>
+          <Text fontSize="sm">{formatDate(launch.launch_date_utc)} </Text>
+          <Text color="gray.500" ml="2" fontSize="sm">
+            {timeAgo(launch.launch_date_utc)}
+          </Text>
+        </Flex>
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/launch-item.js
+++ b/src/components/launch-item.js
@@ -6,7 +6,16 @@ import { Link } from "react-router-dom";
 import { formatDate } from "../utils/format-date";
 import FavouriteLaunchButton from "./favourite-launch-button";
 
-export default function LaunchItem({ launch }) {
+function getImageHeight(variant) {
+  switch (variant) {
+    case "favourites-list":
+      return ["100px", null, "200px"];
+    default:
+      return ["200px", null, "300px"];
+  }
+}
+
+export default function LaunchItem({ launch, variant }) {
   return (
     <Box
       as={Link}
@@ -25,7 +34,7 @@ export default function LaunchItem({ launch }) {
           launch.links.mission_patch_small
         }
         alt={`${launch.mission_name} launch`}
-        height={["200px", null, "300px"]}
+        height={getImageHeight(variant)}
         width="100%"
         objectFit="cover"
         objectPosition="bottom"

--- a/src/components/launch-pad-item.js
+++ b/src/components/launch-pad-item.js
@@ -1,6 +1,7 @@
 import React from "react";
-import { Badge, Box, Text } from "@chakra-ui/core";
+import { Badge, Box, Flex, Text } from "@chakra-ui/core";
 import { Link } from "react-router-dom";
+import FavouriteLaunchPadButton from "./favourite-launch-pad-button";
 
 export default function LaunchPadItem({ launchPad }) {
   return (
@@ -12,6 +13,8 @@ export default function LaunchPadItem({ launchPad }) {
       rounded="lg"
       overflow="hidden"
       position="relative"
+      display="block"
+      aria-label="Launch pad item"
     >
       <Box p="6">
         <Box d="flex" alignItems="baseline">
@@ -37,15 +40,19 @@ export default function LaunchPadItem({ launchPad }) {
           </Box>
         </Box>
 
-        <Box
-          mt="1"
-          fontWeight="semibold"
-          as="h4"
-          lineHeight="tight"
-          isTruncated
-        >
-          {launchPad.name}
-        </Box>
+        <Flex justify="space-between">
+          <Box
+            mt="1"
+            fontWeight="semibold"
+            as="h4"
+            lineHeight="tight"
+            isTruncated
+            aria-label="Launch pad name"
+          >
+            {launchPad.name}
+          </Box>
+          <FavouriteLaunchPadButton launchPadId={launchPad.site_id} />
+        </Flex>
         <Text color="gray.500" fontSize="sm">
           {launchPad.vehicles_launched.join(", ")}
         </Text>

--- a/src/components/launch-pad-item.js
+++ b/src/components/launch-pad-item.js
@@ -1,0 +1,55 @@
+import React from "react";
+import { Badge, Box, Text } from "@chakra-ui/core";
+import { Link } from "react-router-dom";
+
+export default function LaunchPadItem({ launchPad }) {
+  return (
+    <Box
+      as={Link}
+      to={`/launch-pads/${launchPad.site_id}`}
+      boxShadow="md"
+      borderWidth="1px"
+      rounded="lg"
+      overflow="hidden"
+      position="relative"
+    >
+      <Box p="6">
+        <Box d="flex" alignItems="baseline">
+          {launchPad.status === "active" ? (
+            <Badge px="2" variant="solid" variantColor="green">
+              Active
+            </Badge>
+          ) : (
+            <Badge px="2" variant="solid" variantColor="red">
+              Retired
+            </Badge>
+          )}
+          <Box
+            color="gray.500"
+            fontWeight="semibold"
+            letterSpacing="wide"
+            fontSize="xs"
+            textTransform="uppercase"
+            ml="2"
+          >
+            {launchPad.attempted_launches} attempted &bull;{" "}
+            {launchPad.successful_launches} succeeded
+          </Box>
+        </Box>
+
+        <Box
+          mt="1"
+          fontWeight="semibold"
+          as="h4"
+          lineHeight="tight"
+          isTruncated
+        >
+          {launchPad.name}
+        </Box>
+        <Text color="gray.500" fontSize="sm">
+          {launchPad.vehicles_launched.join(", ")}
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/launch-pad.js
+++ b/src/components/launch-pad.js
@@ -21,6 +21,8 @@ import { useSpaceX } from "../utils/use-space-x";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 import LaunchItem from "./launch-item";
+import FavouriteLaunchPads from "./favourite-launch-pads";
+import FavouriteLaunchPadButton from "./favourite-launch-pad-button";
 
 export default function LaunchPad() {
   let { launchPadId } = useParams();
@@ -44,13 +46,16 @@ export default function LaunchPad() {
 
   return (
     <div>
-      <Breadcrumbs
-        items={[
-          { label: "Home", to: "/" },
-          { label: "Launch Pads", to: ".." },
-          { label: launchPad.name },
-        ]}
-      />
+      <Flex justify="space-between" align="center" mx={4}>
+        <Breadcrumbs
+          items={[
+            { label: "Home", to: "/" },
+            { label: "Launch Pads", to: ".." },
+            { label: launchPad.name },
+          ]}
+        />
+        <FavouriteLaunchPads />
+      </Flex>
       <Header launchPad={launchPad} />
       <Box m={[3, 6]}>
         <LocationAndVehicles launchPad={launchPad} />
@@ -91,7 +96,7 @@ function Header({ launchPad }) {
       >
         {launchPad.site_name_long}
       </Heading>
-      <Stack isInline spacing="3">
+      <Stack isInline spacing="3" align="center">
         <Badge variantColor="purple" fontSize={["sm", "md"]}>
           {launchPad.successful_launches}/{launchPad.attempted_launches}{" "}
           successful
@@ -105,6 +110,7 @@ function Header({ launchPad }) {
             Retired
           </Badge>
         )}
+        <FavouriteLaunchPadButton launchPadId={launchPad.site_id} />
       </Stack>
     </Flex>
   );

--- a/src/components/launch-pad.js
+++ b/src/components/launch-pad.js
@@ -20,7 +20,7 @@ import {
 import { useSpaceX } from "../utils/use-space-x";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
-import { LaunchItem } from "./launches";
+import LaunchItem from "./launch-item";
 
 export default function LaunchPad() {
   let { launchPadId } = useParams();

--- a/src/components/launch-pads.js
+++ b/src/components/launch-pads.js
@@ -1,11 +1,12 @@
 import React from "react";
-import { SimpleGrid } from "@chakra-ui/core";
+import { Flex, SimpleGrid } from "@chakra-ui/core";
 
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 import LoadMoreButton from "./load-more-button";
 import { useSpaceXPaginated } from "../utils/use-space-x";
 import LaunchPadItem from "./launch-pad-item";
+import FavouriteLaunchPads from "./favourite-launch-pads";
 
 const PAGE_SIZE = 12;
 
@@ -19,9 +20,12 @@ export default function LaunchPads() {
 
   return (
     <div>
+      <Flex justify="space-between" align="center" mx={4}>
       <Breadcrumbs
         items={[{ label: "Home", to: "/" }, { label: "Launch Pads" }]}
       />
+        <FavouriteLaunchPads />
+      </Flex>
       <SimpleGrid m={[2, null, 6]} minChildWidth="350px" spacing="4">
         {error && <Error />}
         {data &&

--- a/src/components/launch-pads.js
+++ b/src/components/launch-pads.js
@@ -1,11 +1,11 @@
 import React from "react";
-import { Badge, Box, SimpleGrid, Text } from "@chakra-ui/core";
-import { Link } from "react-router-dom";
+import { SimpleGrid } from "@chakra-ui/core";
 
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 import LoadMoreButton from "./load-more-button";
 import { useSpaceXPaginated } from "../utils/use-space-x";
+import LaunchPadItem from "./launch-pad-item";
 
 const PAGE_SIZE = 12;
 
@@ -38,57 +38,5 @@ export default function LaunchPads() {
         isLoadingMore={isValidating}
       />
     </div>
-  );
-}
-
-function LaunchPadItem({ launchPad }) {
-  return (
-    <Box
-      as={Link}
-      to={`/launch-pads/${launchPad.site_id}`}
-      boxShadow="md"
-      borderWidth="1px"
-      rounded="lg"
-      overflow="hidden"
-      position="relative"
-    >
-      <Box p="6">
-        <Box d="flex" alignItems="baseline">
-          {launchPad.status === "active" ? (
-            <Badge px="2" variant="solid" variantColor="green">
-              Active
-            </Badge>
-          ) : (
-            <Badge px="2" variant="solid" variantColor="red">
-              Retired
-            </Badge>
-          )}
-          <Box
-            color="gray.500"
-            fontWeight="semibold"
-            letterSpacing="wide"
-            fontSize="xs"
-            textTransform="uppercase"
-            ml="2"
-          >
-            {launchPad.attempted_launches} attempted &bull;{" "}
-            {launchPad.successful_launches} succeeded
-          </Box>
-        </Box>
-
-        <Box
-          mt="1"
-          fontWeight="semibold"
-          as="h4"
-          lineHeight="tight"
-          isTruncated
-        >
-          {launchPad.name}
-        </Box>
-        <Text color="gray.500" fontSize="sm">
-          {launchPad.vehicles_launched.join(", ")}
-        </Text>
-      </Box>
-    </Box>
   );
 }

--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -27,6 +27,8 @@ import { formatDateTime } from "../utils/format-date";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 import { getLaunchpadTimezone } from "../utils/launch-pad-timezones";
+import FavouriteLaunchButton from "./favourite-launch-button";
+import FavouriteLaunches from "./favourite-launches";
 
 export default function Launch() {
   let { launchId } = useParams();
@@ -43,13 +45,16 @@ export default function Launch() {
 
   return (
     <div>
-      <Breadcrumbs
-        items={[
-          { label: "Home", to: "/" },
-          { label: "Launches", to: ".." },
-          { label: `#${launch.flight_number}` },
-        ]}
-      />
+      <Flex justify="space-between" align="center" mx={4}>
+        <Breadcrumbs
+          items={[
+            { label: "Home", to: "/" },
+            { label: "Launches", to: "../" },
+            { label: `#${launch.flight_number}` },
+          ]}
+        />
+        <FavouriteLaunches />
+      </Flex>
       <Header launch={launch} />
       <Box m={[3, 6]}>
         <TimeAndLocation launch={launch} />
@@ -97,7 +102,7 @@ function Header({ launch }) {
       >
         {launch.mission_name}
       </Heading>
-      <Stack isInline spacing="3">
+      <Stack isInline spacing="3" align="center">
         <Badge variantColor="purple" fontSize={["xs", "md"]}>
           #{launch.flight_number}
         </Badge>
@@ -110,6 +115,7 @@ function Header({ launch }) {
             Failed
           </Badge>
         )}
+        <FavouriteLaunchButton launchId={launch.flight_number} />
       </Stack>
     </Flex>
   );

--- a/src/components/launches.js
+++ b/src/components/launches.js
@@ -5,6 +5,7 @@ import { useSpaceXPaginated } from "../utils/use-space-x";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 import LoadMoreButton from "./load-more-button";
+import FavouriteLaunches from "./favourite-launches";
 import LaunchItem from "./launch-item";
 
 const PAGE_SIZE = 12;
@@ -18,13 +19,15 @@ export default function Launches() {
       sort: "launch_date_utc",
     }
   );
-  console.log(data, error);
   return (
     <div>
-      <Breadcrumbs
-        items={[{ label: "Home", to: "/" }, { label: "Launches" }]}
-      />
-      <SimpleGrid m={[2, null, 6]} minChildWidth="350px" spacing="4">
+      <Flex justify="space-between" align="center" mx={4}>
+        <Breadcrumbs
+          items={[{ label: "Home", to: "/" }, { label: "Launches" }]}
+        />
+        <FavouriteLaunches />
+      </Flex>
+      <SimpleGrid m={[2, null, 6]} mt={[0, null, 0]} minChildWidth="350px" spacing="4">
         {error && <Error />}
         {data &&
           data

--- a/src/components/launches.js
+++ b/src/components/launches.js
@@ -1,13 +1,11 @@
 import React from "react";
-import { Badge, Box, Image, SimpleGrid, Text, Flex } from "@chakra-ui/core";
-import { format as timeAgo } from "timeago.js";
-import { Link } from "react-router-dom";
+import { SimpleGrid, Flex } from "@chakra-ui/core";
 
 import { useSpaceXPaginated } from "../utils/use-space-x";
-import { formatDate } from "../utils/format-date";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 import LoadMoreButton from "./load-more-button";
+import LaunchItem from "./launch-item";
 
 const PAGE_SIZE = 12;
 
@@ -45,78 +43,3 @@ export default function Launches() {
   );
 }
 
-export function LaunchItem({ launch }) {
-  return (
-    <Box
-      as={Link}
-      to={`/launches/${launch.flight_number.toString()}`}
-      boxShadow="md"
-      borderWidth="1px"
-      rounded="lg"
-      overflow="hidden"
-      position="relative"
-    >
-      <Image
-        src={
-          launch.links.flickr_images[0]?.replace("_o.jpg", "_z.jpg") ??
-          launch.links.mission_patch_small
-        }
-        alt={`${launch.mission_name} launch`}
-        height={["200px", null, "300px"]}
-        width="100%"
-        objectFit="cover"
-        objectPosition="bottom"
-      />
-
-      <Image
-        position="absolute"
-        top="5"
-        right="5"
-        src={launch.links.mission_patch_small}
-        height="75px"
-        objectFit="contain"
-        objectPosition="bottom"
-      />
-
-      <Box p="6">
-        <Box d="flex" alignItems="baseline">
-          {launch.launch_success ? (
-            <Badge px="2" variant="solid" variantColor="green">
-              Successful
-            </Badge>
-          ) : (
-            <Badge px="2" variant="solid" variantColor="red">
-              Failed
-            </Badge>
-          )}
-          <Box
-            color="gray.500"
-            fontWeight="semibold"
-            letterSpacing="wide"
-            fontSize="xs"
-            textTransform="uppercase"
-            ml="2"
-          >
-            {launch.rocket.rocket_name} &bull; {launch.launch_site.site_name}
-          </Box>
-        </Box>
-
-        <Box
-          mt="1"
-          fontWeight="semibold"
-          as="h4"
-          lineHeight="tight"
-          isTruncated
-        >
-          {launch.mission_name}
-        </Box>
-        <Flex>
-          <Text fontSize="sm">{formatDate(launch.launch_date_utc)} </Text>
-          <Text color="gray.500" ml="2" fontSize="sm">
-            {timeAgo(launch.launch_date_utc)}
-          </Text>
-        </Flex>
-      </Box>
-    </Box>
-  );
-}

--- a/src/utils/favourites-context.js
+++ b/src/utils/favourites-context.js
@@ -2,6 +2,7 @@ import React, { useContext, useMemo, useReducer } from "react";
 
 const INITIAL_STATE = {
   launches: [],
+  launchPads: [],
 };
 
 const FavouritesContext = React.createContext();
@@ -17,6 +18,16 @@ function reducer(state, action) {
       return {
         ...state,
         launches: state.launches.filter((launch) => launch !== action.launchId),
+      };
+    case "addFavouriteLaunchPad":
+      return {
+        ...state,
+        launchPads: [...state.launchPads, action.launchPadId],
+      };
+    case "removeFavouriteLaunchPad":
+      return {
+        ...state,
+        launchPads: state.launchPads.filter((launch) => launch !== action.launchPadId),
       };
     default:
       return state;
@@ -41,6 +52,18 @@ export function FavouritesContextProvider({ children }) {
           launchId,
         });
       },
+      addFavouriteLaunchPad: function(launchPadId) {
+        dispatch({
+          type: "addFavouriteLaunchPad",
+          launchPadId,
+        });
+      },
+      removeFavouriteLaunchPad: function(launchPadId) {
+        dispatch({
+          type: "removeFavouriteLaunchPad",
+          launchPadId,
+        });
+      }
     }),
     [state],
   );
@@ -76,5 +99,28 @@ export function useFavouriteLaunch(launchId) {
   return {
     isFavourite,
     toggleFavouriteLaunch,
+  };
+}
+
+export function useFavouriteLaunchPads() {
+  return useFavouritesContext().state.launchPads;
+}
+
+export function useFavouriteLaunchPad(launchPadId) {
+  const { state, addFavouriteLaunchPad, removeFavouriteLaunchPad } = useFavouritesContext();
+
+  const isFavourite = state.launchPads.includes(launchPadId);
+
+  function toggleFavouriteLaunchPad() {
+    if (isFavourite) {
+      removeFavouriteLaunchPad(launchPadId);
+    } else {
+      addFavouriteLaunchPad(launchPadId);
+    }
+  }
+
+  return {
+    isFavourite,
+    toggleFavouriteLaunchPad,
   };
 }

--- a/src/utils/favourites-context.js
+++ b/src/utils/favourites-context.js
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo, useReducer } from "react";
+import React, { useContext, useEffect, useMemo, useReducer } from "react";
 
 const INITIAL_STATE = {
   launches: [],
@@ -34,8 +34,14 @@ function reducer(state, action) {
   }
 }
 
+const initialState = loadFavouritesFromLocalStorage();
+
 export function FavouritesContextProvider({ children }) {
-  const [state, dispatch] = useReducer(reducer, INITIAL_STATE);
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  useEffect(() => {
+    saveFavouritesToLocalStorage(state);
+  }, [state]);
 
   const value = useMemo(
     () => ({
@@ -73,6 +79,22 @@ export function FavouritesContextProvider({ children }) {
       {children}
     </FavouritesContext.Provider>
   );
+}
+
+function saveFavouritesToLocalStorage(state) {
+  localStorage.setItem("favourites", JSON.stringify(state));
+}
+
+function loadFavouritesFromLocalStorage() {
+  const savedState = localStorage.getItem("favourites");
+  if (savedState) {
+    try {
+      return JSON.parse(savedState);
+    } catch (error) {
+      console.error(new Error(`Failed to load favourites from local storage: ${error.message}`));
+    }
+  }
+  return INITIAL_STATE;
 }
 
 function useFavouritesContext() {

--- a/src/utils/favourites-context.js
+++ b/src/utils/favourites-context.js
@@ -1,0 +1,80 @@
+import React, { useContext, useMemo, useReducer } from "react";
+
+const INITIAL_STATE = {
+  launches: [],
+};
+
+const FavouritesContext = React.createContext();
+
+function reducer(state, action) {
+  switch (action.type) {
+    case "addFavouriteLaunch":
+      return {
+        ...state,
+        launches: [...state.launches, action.launchId],
+      };
+    case "removeFavouriteLaunch":
+      return {
+        ...state,
+        launches: state.launches.filter((launch) => launch !== action.launchId),
+      };
+    default:
+      return state;
+  }
+}
+
+export function FavouritesContextProvider({ children }) {
+  const [state, dispatch] = useReducer(reducer, INITIAL_STATE);
+
+  const value = useMemo(
+    () => ({
+      state,
+      addFavouriteLaunch: function (launchId) {
+        dispatch({
+          type: "addFavouriteLaunch",
+          launchId,
+        });
+      },
+      removeFavouriteLaunch: function (launchId) {
+        dispatch({
+          type: "removeFavouriteLaunch",
+          launchId,
+        });
+      },
+    }),
+    [state],
+  );
+
+  return (
+    <FavouritesContext.Provider value={value}>
+      {children}
+    </FavouritesContext.Provider>
+  );
+}
+
+function useFavouritesContext() {
+  return useContext(FavouritesContext);
+}
+
+export function useFavouriteLaunches() {
+  return useFavouritesContext().state.launches;
+}
+
+export function useFavouriteLaunch(launchId) {
+  const { state, addFavouriteLaunch, removeFavouriteLaunch } = useFavouritesContext();
+
+  const isFavourite = state.launches.includes(launchId);
+
+  function toggleFavouriteLaunch() {
+    if (isFavourite) {
+      removeFavouriteLaunch(launchId);
+    } else {
+      addFavouriteLaunch(launchId);
+    }
+  }
+
+  return {
+    isFavourite,
+    toggleFavouriteLaunch,
+  };
+}


### PR DESCRIPTION
## Implementation
* I could make the favourite list components (favourite-launches, favourite-launch-pads) DRYer but I didn’t like the way the reusable component would look
* Separate API calls for individual favourite items is not optimal. However I didn't find a batching endpoint in the API docs.


## Next steps
Here's a list of features that I've decided not to include in the scope of this task
* Adding a loader while fetching data about favourite items.
* Pagination of favourite items - all are loaded at the same time
* When parsing the JSON from local storage on app init, validate the incoming data so that they don’t break the app, for example if they got corrupted but still passed as valid JSON.
* When entering a launch detail from the favourites list, the list disappears. After hitting the browser back button, the list is not visible and user needs to click and scroll to get to the previous state in the list. This could be solved in multiple ways, for example we could store the last scroll position in context, or the favourites list could be on a dedicated page, not in a drawer, so the browser would remember the last scroll position for us.