### PR TITLE
Add launches filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-feather": "^2.0.8",
-    "react-router": "^6.0.0-alpha.3",
-    "react-router-dom": "^6.0.0-alpha.3",
+    "react-router": "^6.0.2",
+    "react-router-dom": "^6.0.2",
     "react-scripts": "3.4.3",
     "swr": "^0.3.0",
     "timeago.js": "^4.0.2"

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -8,19 +8,22 @@ import Home from "./home";
 import LaunchPads from "./launch-pads";
 import LaunchPad from "./launch-pad";
 import { FavouritesContextProvider } from "../utils/favourites-context";
+import { LaunchFiltersContextProvider } from "../utils/launch-filters-context";
 
 export default function App() {
   return (
     <div>
       <FavouritesContextProvider>
-        <NavBar />
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/launches" element={<Launches />} />
-          <Route path="/launches/:launchId" element={<Launch />} />
-          <Route path="/launch-pads" element={<LaunchPads />} />
-          <Route path="/launch-pads/:launchPadId" element={<LaunchPad />} />
-        </Routes>
+        <LaunchFiltersContextProvider>
+          <NavBar />
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/launches" element={<Launches />} />
+            <Route path="/launches/:launchId" element={<Launch />} />
+            <Route path="/launch-pads" element={<LaunchPads />} />
+            <Route path="/launch-pads/:launchPadId" element={<LaunchPad />} />
+          </Routes>
+        </LaunchFiltersContextProvider>
       </FavouritesContextProvider>
     </div>
   );

--- a/src/components/launch-filters.js
+++ b/src/components/launch-filters.js
@@ -1,0 +1,36 @@
+import { Checkbox, Input, Stack } from "@chakra-ui/core";
+import React from "react";
+import { useLaunchFiltersContext } from "../utils/launch-filters-context";
+
+export default function LaunchFilters() {
+  const {
+    query,
+    setQuery,
+    showSuccessful,
+    setShowSuccessful,
+    showFailed,
+    setShowFailed,
+  } = useLaunchFiltersContext();
+
+  return (
+    <Stack spacing={10} m={6} mt={0} maxWidth="600px" direction="row">
+      <Input
+        placeholder="Filter missions, rockets, sites..."
+        onChange={(event) => setQuery(event.currentTarget.value)}
+        value={query}
+      />
+        <Checkbox
+          isChecked={showSuccessful}
+          onChange={(event) => setShowSuccessful(event.target.checked)}
+        >
+          Successful
+        </Checkbox>
+        <Checkbox
+          isChecked={showFailed}
+          onChange={(event) => setShowFailed(event.target.checked)}
+        >
+          Failed
+        </Checkbox>
+    </Stack>
+  );
+}

--- a/src/components/launch-pad.js
+++ b/src/components/launch-pad.js
@@ -50,7 +50,7 @@ export default function LaunchPad() {
         <Breadcrumbs
           items={[
             { label: "Home", to: "/" },
-            { label: "Launch Pads", to: ".." },
+            { label: "Launch Pads", to: "/launch-pads" },
             { label: launchPad.name },
           ]}
         />

--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -49,7 +49,7 @@ export default function Launch() {
         <Breadcrumbs
           items={[
             { label: "Home", to: "/" },
-            { label: "Launches", to: "../" },
+            { label: "Launches", to: "/launches" },
             { label: `#${launch.flight_number}` },
           ]}
         />

--- a/src/components/launches.js
+++ b/src/components/launches.js
@@ -1,24 +1,19 @@
 import React from "react";
 import { SimpleGrid, Flex } from "@chakra-ui/core";
 
-import { useSpaceXPaginated } from "../utils/use-space-x";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 import LoadMoreButton from "./load-more-button";
 import FavouriteLaunches from "./favourite-launches";
 import LaunchItem from "./launch-item";
+import LaunchFilters from "./launch-filters";
+import { useLaunches } from "../utils/launch-filters-context";
 
 const PAGE_SIZE = 12;
 
 export default function Launches() {
-  const { data, error, isValidating, setSize, size } = useSpaceXPaginated(
-    "/launches/past",
-    {
-      limit: PAGE_SIZE,
-      order: "desc",
-      sort: "launch_date_utc",
-    }
-  );
+  const { data, error, isValidating, setSize, size } = useFilteredLaunches(PAGE_SIZE);
+
   return (
     <div>
       <Flex justify="space-between" align="center" mx={4}>

--- a/src/components/launches.js
+++ b/src/components/launches.js
@@ -7,7 +7,7 @@ import LoadMoreButton from "./load-more-button";
 import FavouriteLaunches from "./favourite-launches";
 import LaunchItem from "./launch-item";
 import LaunchFilters from "./launch-filters";
-import { useLaunches } from "../utils/launch-filters-context";
+import { useFilteredLaunches } from "../utils/launch-filters-context";
 
 const PAGE_SIZE = 12;
 
@@ -22,11 +22,11 @@ export default function Launches() {
         />
         <FavouriteLaunches />
       </Flex>
+      <LaunchFilters />
       <SimpleGrid m={[2, null, 6]} mt={[0, null, 0]} minChildWidth="350px" spacing="4">
         {error && <Error />}
         {data &&
           data
-            .flat()
             .map((launch) => (
               <LaunchItem launch={launch} key={launch.flight_number} />
             ))}

--- a/src/utils/launch-filters-context.js
+++ b/src/utils/launch-filters-context.js
@@ -1,3 +1,5 @@
+import React, { useContext, useMemo } from "react";
+import { useSearchParam } from "./use-search-param";
 import { useSpaceXPaginated } from "./use-space-x";
 
 export function useLaunches(pageSize) {
@@ -9,4 +11,79 @@ export function useLaunches(pageSize) {
       sort: "launch_date_utc",
     }
   );
+}
+
+export function useFilteredLaunches(pageSize) {
+  const result = useLaunches(pageSize);
+  const {
+    query,
+    showSuccessful,
+    showFailed,
+  } = useLaunchFiltersContext();
+
+  const data = useMemo(() => (result.data ?? []).flat(), [result.data]);
+
+  const filteredData = useMemo(
+    () => data.filter((launch) => {
+        if (query !== "") {
+          return [
+            launch.mission_name,
+            launch.rocket.rocket_name,
+            launch.launch_site.site_name,
+          ].some((name) => (name ?? "").toLowerCase().includes(query.toLowerCase()));
+        }
+        return true;
+      })
+      .filter((launch) => {
+        if (launch.launch_success) {
+          return showSuccessful;
+        } else {
+          return showFailed;
+        }
+      }),
+      [data, query, showFailed, showSuccessful],
+  );
+
+  return useMemo(() => ({
+    ...result,
+    data: filteredData,
+  }), [filteredData, result]);
+}
+
+const LaunchFiltersContext = React.createContext();
+
+export function LaunchFiltersContextProvider({ children }) {
+  const [query, setQuery] = useSearchParam("query", "");
+  const [showSuccessful, setShowSuccessful] = useSearchParam("showSuccessful", true);
+  const [showFailed, setShowFailed] = useSearchParam("showFailed", true);
+
+  const value = useMemo(
+    () => ({
+      query,
+      setQuery,
+      showSuccessful: parseBooleanQueryParam(showSuccessful) ?? true,
+      setShowSuccessful,
+      showFailed: parseBooleanQueryParam(showFailed) ?? true,
+      setShowFailed,
+    }),
+    [query, setQuery, setShowFailed, setShowSuccessful, showFailed, showSuccessful]
+  );
+
+  return (
+    <LaunchFiltersContext.Provider value={value}>
+      {children}
+    </LaunchFiltersContext.Provider>
+  );
+}
+
+export function useLaunchFiltersContext() {
+  return useContext(LaunchFiltersContext);
+}
+
+function parseBooleanQueryParam(param) {
+  try {
+    return JSON.parse(param);
+  } catch (error) {
+    return;
+  }
 }

--- a/src/utils/launch-filters-context.js
+++ b/src/utils/launch-filters-context.js
@@ -1,0 +1,12 @@
+import { useSpaceXPaginated } from "./use-space-x";
+
+export function useLaunches(pageSize) {
+  return useSpaceXPaginated(
+    "/launches/past",
+    {
+      limit: pageSize,
+      order: "desc",
+      sort: "launch_date_utc",
+    }
+  );
+}

--- a/src/utils/use-search-param.js
+++ b/src/utils/use-search-param.js
@@ -1,0 +1,21 @@
+import { useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
+
+/**
+ * @returns Similar to useState hook, it returns a current value for given
+ * query parameter and a Setter method that updates parameter in URL
+ */
+export function useSearchParam (key, defaultValue) {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  return useMemo(() => {
+    const value = searchParams.get(key) ?? defaultValue;
+    function setSearchParam(value) {
+      setSearchParams({
+        ...Object.fromEntries(searchParams),
+        [key]: value,
+      }, { replace: true });
+    }
+    return [value, setSearchParam];
+  }, [defaultValue, key, searchParams, setSearchParams]);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5803,10 +5803,10 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-history@5.0.0-beta.4:
-  version "5.0.0-beta.4"
-  resolved "https://registry.yarnpkg.com/history/-/history-5.0.0-beta.4.tgz#7fd3bb1f6c75d00d9b5112a816766bfc72d1a3cd"
-  integrity sha512-LMUnKPB5UlEzDF1BO0VxtDsrguGPO7SuQEmB/5OjL1305afR1O8FvX29rbJep4g2SLmKK3YdDA7+8ZDs8P8n8g==
+history@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-5.1.0.tgz#2e93c09c064194d38d52ed62afd0afc9d9b01ece"
+  integrity sha512-zPuQgPacm2vH2xdORvGGz1wQMuHSIB56yNAy5FnLuwOwgSYyPKptJtcMm6Ev+hRGeS+GzhbmRacHzvlESbFwDg==
   dependencies:
     "@babel/runtime" "^7.7.6"
 
@@ -9655,21 +9655,20 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-router-dom@^6.0.0-alpha.3:
-  version "6.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.0.0-alpha.3.tgz#295aa7691de913b81f481b7cb14418e3b2f08edf"
-  integrity sha512-3Fu9Az+ofgv58WxtaPokADdNXJmxE6td5na2HFIN0cgRBYo2TPJ83KlIt4XCNvq1Y473pr8hOkD621CmauztEw==
+react-router-dom@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.0.2.tgz#860cefa697b9d4965eced3f91e82cdbc5995f3ad"
+  integrity sha512-cOpJ4B6raFutr0EG8O/M2fEoyQmwvZWomf1c6W2YXBZuFBx8oTk/zqjXghwScyhfrtnt0lANXV2182NQblRxFA==
   dependencies:
-    history "5.0.0-beta.4"
-    prop-types "^15.7.2"
+    history "^5.1.0"
+    react-router "6.0.2"
 
-react-router@^6.0.0-alpha.3:
-  version "6.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.0.0-alpha.3.tgz#c031a5262801315571f8b609620ae9c1b083dee3"
-  integrity sha512-Evp8ua5c7rFDIuF0KK/tkzbh7aPIWWyjWKr3yOLNine1liiphHZidDL/5jLTBjE9HN0/vdCZPuV2VWjZ82TShA==
+react-router@6.0.2, react-router@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.0.2.tgz#bd2b0fa84fd1d152671e9f654d9c0b1f5a7c86da"
+  integrity sha512-8/Wm3Ed8t7TuedXjAvV39+c8j0vwrI5qVsYqjFr5WkJjsJpEvNSoLRUbtqSEYzqaTUj1IV+sbPJxvO+accvU0Q==
   dependencies:
-    history "5.0.0-beta.4"
-    prop-types "^15.7.2"
+    history "^5.1.0"
 
 react-scripts@3.4.3:
   version "3.4.3"


### PR DESCRIPTION
At last, I've actually added some extra feature to the app. It's a pretty boring "live" filter of the launches. I tried to make it interesting by keeping the filter state in sync with the current URL.

If I was more adventurous, I could also move the pagination to search params so that the whole "state" of the page is easily shared across browsers.

Unfortunately I didn't find time to add anything more and I'm already past the deadline, hope I was able to show at least some of my skills in this.

I was tempted to use a few more libraries that I'm used to nowadays (lodash, jotai, react-use) but thought it would be more appropriate to keep things more "vanilla".

No tests in this one (sorry future me)